### PR TITLE
General Fixes and Updates

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -158,16 +158,18 @@ func ControllerPublishVolume(
 	volumeID *csi.VolumeID,
 	volumeMetadata *csi.VolumeMetadata,
 	nodeID *csi.NodeID,
+	volumeCapability *csi.VolumeCapability,
 	readonly bool,
 	callOpts ...grpc.CallOption) (
 	*csi.PublishVolumeInfo, error) {
 
 	req := &csi.ControllerPublishVolumeRequest{
-		Version:        version,
-		VolumeId:       volumeID,
-		VolumeMetadata: volumeMetadata,
-		NodeId:         nodeID,
-		Readonly:       readonly,
+		Version:          version,
+		VolumeId:         volumeID,
+		VolumeMetadata:   volumeMetadata,
+		NodeId:           nodeID,
+		Readonly:         readonly,
+		VolumeCapability: volumeCapability,
 	}
 
 	res, err := c.ControllerPublishVolume(ctx, req, callOpts...)

--- a/csc/main.go
+++ b/csc/main.go
@@ -202,7 +202,7 @@ const volumeInfoFormat = `{{with .GetId}}{{range $k, $v := .GetValues}}` +
 	`{{printf "%s=%s\t" $k $v}}{{end}}{{end}}{{"\n"}}`
 
 // versionFormat is the default Go template format for emitting a *csi.Version
-const versionFormat = `{{.GetMajor}}.{{.GetMinor}}.{{.GetPatch}}`
+const versionFormat = `{{.GetMajor}}.{{.GetMinor}}.{{.GetPatch}}{{"\n"}}`
 
 // pluginInfoFormat is the default Go template format for
 // emitting a *csi.GetPluginInfoResponse_Result
@@ -212,12 +212,7 @@ const pluginInfoFormat = `{{.Name}}{{print "\t"}}{{.VendorVersion}}{{print "\t"}
 
 // capFormat is the default Go template for emitting a
 // *csi.{Controller,Node}ServiceCapability
-const capFormat = `{{with .GetRpc}}{{.}}{{end}}` +
-	`{{with .GetVolumeCapability}}` +
-	`{{with .GetBlock}}{{.}}{{end}}{{with .GetMount}}MountVolume` +
-	`{{with .GetFsType}}{{print "\n\tfs_type: "}}{{.}}{{end}}` +
-	`{{with .GetMountFlags}}{{print "\n\tmount_flags: "}}{{.}}{{end}}` +
-	`{{end}}{{end}}{{"\n"}}`
+const capFormat = `{{with .GetRpc}}{{.Type}}{{end}}{{"\n"}}`
 
 // valCapFormat is the default Go tempate for emitting a
 // *csi.ValidateVolumeCapabilitiesResponse_Result

--- a/csc/node.go
+++ b/csc/node.go
@@ -379,7 +379,7 @@ func flagsNodeGetCapabilities(
 	ctx context.Context, rpc string) *flag.FlagSet {
 
 	fs := flag.NewFlagSet(rpc, flag.ExitOnError)
-	flagsGlobal(fs, capFormat, "*csi.nodeGetCapabilitiesResponse_Result")
+	flagsGlobal(fs, capFormat, "[]*csi.NodeServiceCapability")
 
 	fs.Usage = func() {
 		fmt.Fprintf(

--- a/interceptors_server.go
+++ b/interceptors_server.go
@@ -273,6 +273,10 @@ func (v *serverRepLogger) handle(
 		return rep, err
 	}
 
+	if rep == nil {
+		return nil, nil
+	}
+
 	var gocsiErr error
 
 	switch trep := rep.(type) {


### PR DESCRIPTION
This patch includes the following fixes and updates:

* The `csc controllerpublishvolume` command can now accept the data used to construct a volume capability object.
* The library's `ControllerPublishVolume` function can now accept the address of a `csi.VolumeCapability` object.
* The server-side response logger checks for a nil response.