### PR TITLE
GetMounts now uses /proc/self/mountinfo for Linux

### DIFF
--- a/idempotent_interceptor.go
+++ b/idempotent_interceptor.go
@@ -30,7 +30,10 @@ type IdempotencyProvider interface {
 
 	// IsNodePublished should return a flag indicating whether or
 	// not the volume exists and is published on the current host.
-	IsNodePublished(id *csi.VolumeID, targetPath string) (bool, error)
+	IsNodePublished(
+		id *csi.VolumeID,
+		pubVolInfo *csi.PublishVolumeInfo,
+		targetPath string) (bool, error)
 }
 
 // NewIdempotentInterceptor returns a new server-side, gRPC interceptor
@@ -275,7 +278,8 @@ func (i *idempotencyInterceptor) nodePublishVolume(
 	}
 	defer lock.Unlock()
 
-	ok, err := i.p.IsNodePublished(req.VolumeId, req.TargetPath)
+	ok, err := i.p.IsNodePublished(
+		req.VolumeId, req.PublishVolumeInfo, req.TargetPath)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +319,7 @@ func (i *idempotencyInterceptor) nodeUnpublishVolume(
 	}
 	defer lock.Unlock()
 
-	ok, err := i.p.IsNodePublished(req.VolumeId, req.TargetPath)
+	ok, err := i.p.IsNodePublished(req.VolumeId, nil, req.TargetPath)
 	if err != nil {
 		return nil, err
 	}

--- a/mount/mount_darwin.go
+++ b/mount/mount_darwin.go
@@ -46,10 +46,18 @@ func getMounts() ([]*Info, error) {
 		if len(m) != 4 {
 			continue
 		}
-		if m[3] == "" {
-			return nil, fmt.Errorf("invalid mount options: %s", m[1])
+		device := m[1]
+		if !strings.HasPrefix(device, "/") {
+			continue
 		}
-		options := strings.Split(m[3], ",")
+		var (
+			path    = m[2]
+			source  = device
+			options = strings.Split(m[3], ",")
+		)
+		if len(options) == 0 {
+			return nil, fmt.Errorf("invalid mount options: %s", device)
+		}
 		for i, v := range options {
 			options[i] = strings.TrimSpace(v)
 		}
@@ -60,8 +68,9 @@ func getMounts() ([]*Info, error) {
 			options = nil
 		}
 		mps = append(mps, &Info{
-			Device: m[1],
-			Path:   m[2],
+			Device: device,
+			Path:   path,
+			Source: source,
 			Type:   fsType,
 			Opts:   options,
 		})

--- a/mount/mount_linux.go
+++ b/mount/mount_linux.go
@@ -1,30 +1,30 @@
 package mount
 
 import (
-	"bufio"
 	"fmt"
-	"hash/fnv"
-	"io"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
 
 const (
-	mountFilePath = "/proc/mounts"
-
-	// How many times to retry for a consistent read of /proc/mounts.
-	maxListTries = 3
-	// Number of fields per line in /proc/mounts as per the fstab man page.
-	expectedNumFieldsPerLine = 6
+	procMountsPath = "/proc/self/mountinfo"
+	// procMountsRetries is number of times to retry for a consistent
+	// read of procMountsPath.
+	procMountsRetries = 3
 )
 
 var (
 	bindRemountOpts = []string{"remount"}
 )
+
+func init() {
+	if _, err := os.Stat(procSelfMountInfo); !os.IsNotExist(err) {
+		MountNamespaceSupportEnabled = true
+	}
+}
 
 // getDiskFormat uses 'lsblk' to see if the given disk is unformatted
 func getDiskFormat(disk string) (string, error) {
@@ -127,15 +127,24 @@ func formatAndMount(source, target, fsType string, options []string) error {
 		fsType, existingFormat, mountErr)
 }
 
+// bindMount performs a bind mount
+func bindMount(source, target string, options []string) error {
+	err := doMount("mount", source, target, "", []string{"bind"})
+	if err != nil {
+		return err
+	}
+	return doMount("mount", source, target, "", options)
+}
+
 // getMounts returns a slice of all the mounted filesystems
 func getMounts() ([]*Info, error) {
-	_, hash1, err := readProcMounts(mountFilePath, false)
+	_, hash1, err := readProcMounts(procMountsPath, false)
 	if err != nil {
 		return nil, err
 	}
 
-	for i := 0; i < maxListTries; i++ {
-		mps, hash2, err := readProcMounts(mountFilePath, true)
+	for i := 0; i < procMountsRetries; i++ {
+		mps, hash2, err := readProcMounts(procMountsPath, true)
 		if err != nil {
 			return nil, err
 		}
@@ -147,78 +156,17 @@ func getMounts() ([]*Info, error) {
 	}
 	return nil, fmt.Errorf(
 		"failed to get a consistent snapshot of %v after %d tries",
-		mountFilePath, maxListTries)
+		procMountsPath, procMountsRetries)
 }
 
-// bindMount performs a bind mount
-func bindMount(source, target string, options []string) error {
-	err := doMount("mount", source, target, "", []string{"bind"})
-	if err != nil {
-		return err
-	}
-	return doMount("mount", source, target, "", options)
-}
+// readProcMounts reads procMountsInfo and produce a hash
+// of the contents and a list of the mounts as Info objects.
+func readProcMounts(path string, info bool) ([]*Info, uint32, error) {
 
-// readProcMounts reads the given mountFilePath (normally /proc/mounts)
-// and produces a hash of the contents and a list of the mounts as
-// Info objects.
-func readProcMounts(mountFilePath string, info bool) ([]*Info, uint32, error) {
-
-	file, err := os.Open(mountFilePath)
+	file, err := os.Open(path)
 	if err != nil {
 		return nil, 0, err
 	}
 	defer file.Close()
-	return readProcMountsFrom(file, info)
-}
-
-func readProcMountsFrom(file io.Reader, info bool) ([]*Info, uint32, error) {
-
-	var mountPoints []*Info
-	if info {
-		mountPoints = []*Info{}
-	}
-
-	hash := fnv.New32a()
-	scanner := bufio.NewReader(file)
-	for {
-		line, err := scanner.ReadString('\n')
-		if err == io.EOF {
-			break
-		}
-		fields := strings.Fields(line)
-		if len(fields) != expectedNumFieldsPerLine {
-			return nil, 0, fmt.Errorf(
-				"wrong number of fields (expected %d, got %d): %s",
-				expectedNumFieldsPerLine, len(fields), line)
-		}
-
-		fmt.Fprintf(hash, "%s", line)
-
-		if !info {
-			continue
-		}
-
-		mp := &Info{
-			Device: fields[0],
-			Path:   fields[1],
-			Type:   fields[2],
-			Opts:   strings.Split(fields[3], ","),
-		}
-
-		freq, err := strconv.Atoi(fields[4])
-		if err != nil {
-			return nil, 0, err
-		}
-		mp.Freq = freq
-
-		pass, err := strconv.Atoi(fields[5])
-		if err != nil {
-			return nil, 0, err
-		}
-		mp.Pass = pass
-
-		mountPoints = append(mountPoints, mp)
-	}
-	return mountPoints, hash.Sum32(), nil
+	return readProcMountsFrom(file, info, procMountsFields)
 }

--- a/mount/mount_utils.go
+++ b/mount/mount_utils.go
@@ -1,0 +1,135 @@
+package mount
+
+import (
+	"bufio"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"path"
+	"strings"
+)
+
+// procMountsFields is fields per line in procMountsPath as per
+// https://www.kernel.org/doc/Documentation/filesystems/proc.txt
+const procMountsFields = 9
+
+/*
+From https://www.kernel.org/doc/Documentation/filesystems/proc.txt:
+
+3.5	/proc/<pid>/mountinfo - Information about mounts
+--------------------------------------------------------
+
+This file contains lines of the form:
+
+36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
+(1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
+
+(1) mount ID:  unique identifier of the mount (may be reused after umount)
+(2) parent ID:  ID of parent (or of self for the top of the mount tree)
+(3) major:minor:  value of st_dev for files on filesystem
+(4) root:  root of the mount within the filesystem
+(5) mount point:  mount point relative to the process's root
+(6) mount options:  per mount options
+(7) optional fields:  zero or more fields of the form "tag[:value]"
+(8) separator:  marks the end of the optional fields
+(9) filesystem type:  name of filesystem of the form "type[.subtype]"
+(10) mount source:  filesystem specific information or "none"
+(11) super options:  per super block options
+
+Parsers should ignore all unrecognised optional fields.  Currently the
+possible optional fields are:
+
+shared:X  mount is shared in peer group X
+master:X  mount is slave to peer group X
+propagate_from:X  mount is slave and receives propagation from peer group X (*)
+unbindable  mount is unbindable
+*/
+func readProcMountsFrom(
+	file io.Reader,
+	info bool,
+	expectedFields int) ([]*Info, uint32, error) {
+
+	var (
+		mountPoints []*Info
+		mountSrcMap map[string]string
+	)
+
+	if info {
+		mountPoints = []*Info{}
+		mountSrcMap = map[string]string{}
+	}
+
+	hash := fnv.New32a()
+	scanner := bufio.NewReader(file)
+	for {
+		line, err := scanner.ReadString('\n')
+
+		if err == io.EOF {
+			break
+		}
+
+		fields := strings.Fields(line)
+
+		// Remove the optional fields that should be ignored.
+		for {
+			val := fields[6]
+			fields = append(fields[:6], fields[7:]...)
+			if val == "-" {
+				break
+			}
+		}
+
+		if len(fields) != expectedFields {
+			return nil, 0, fmt.Errorf(
+				"wrong number of fields (expected %d, got %d): %s",
+				expectedFields, len(fields), line)
+		}
+
+		// Skip any lines where the source does not start with a leading
+		// slash. This means this is not a mount on a "real" device.
+		source := fields[7]
+		if !strings.HasPrefix(source, "/") {
+			continue
+		}
+
+		fmt.Fprintf(hash, "%s", line)
+
+		if !info {
+			continue
+		}
+
+		var (
+			bindMountSource string
+
+			root       = fields[3]
+			mountPoint = fields[4]
+			mountOpts  = strings.Split(fields[5], ",")
+			fsType     = fields[6]
+		)
+
+		// If this is the first time a source is encountered in the
+		// output then cache its mountPoint field as the filesystem path
+		// to which the source is mounted as a non-bind mount.
+		//
+		// Subsequent encounters with the source will resolve it
+		// to the cached root value in order to set the mount info's
+		// Source field to the the cached mountPont field value + the
+		// value of the current line's root field.
+		if cachedMountPoint, ok := mountSrcMap[source]; ok {
+			bindMountSource = path.Join(cachedMountPoint, root)
+		} else {
+			mountSrcMap[source] = mountPoint
+		}
+
+		mp := &Info{
+			Device: source,
+			Path:   mountPoint,
+			Source: bindMountSource,
+			Type:   fsType,
+			Opts:   mountOpts,
+		}
+
+		mountPoints = append(mountPoints, mp)
+	}
+	return mountPoints, hash.Sum32(), nil
+}

--- a/mount/mount_utils_test.go
+++ b/mount/mount_utils_test.go
@@ -1,0 +1,61 @@
+package mount
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadProcMountsFrom(t *testing.T) {
+	r := strings.NewReader(procMountInfoData)
+	mis, _, err := readProcMountsFrom(r, true, procMountsFields)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("len(mounts)=%d", len(mis))
+	success := false
+	for _, mi := range mis {
+		t.Logf("%+v", mi)
+		if mi.Path == "/home/akutz/2" && mi.Source == "/home/akutz/1" {
+			success = true
+		}
+	}
+	if !success {
+		t.FailNow()
+	}
+}
+
+const procMountInfoData = `17 60 0:16 / /sys rw,nosuid,nodev,noexec,relatime shared:6 - sysfs sysfs rw,seclabel
+18 60 0:3 / /proc rw,nosuid,nodev,noexec,relatime shared:5 - proc proc rw
+19 60 0:5 / /dev rw,nosuid shared:2 - devtmpfs devtmpfs rw,seclabel,size=1930460k,nr_inodes=482615,mode=755
+20 17 0:15 / /sys/kernel/security rw,nosuid,nodev,noexec,relatime shared:7 - securityfs securityfs rw
+21 19 0:17 / /dev/shm rw,nosuid,nodev shared:3 - tmpfs tmpfs rw,seclabel
+22 19 0:11 / /dev/pts rw,nosuid,noexec,relatime shared:4 - devpts devpts rw,seclabel,gid=5,mode=620,ptmxmode=000
+23 60 0:18 / /run rw,nosuid,nodev shared:23 - tmpfs tmpfs rw,seclabel,mode=755
+24 17 0:19 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:8 - tmpfs tmpfs ro,seclabel,mode=755
+25 24 0:20 / /sys/fs/cgroup/systemd rw,nosuid,nodev,noexec,relatime shared:9 - cgroup cgroup rw,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd
+26 17 0:21 / /sys/fs/pstore rw,nosuid,nodev,noexec,relatime shared:20 - pstore pstore rw
+27 24 0:22 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:10 - cgroup cgroup rw,cpuacct,cpu
+28 24 0:23 / /sys/fs/cgroup/hugetlb rw,nosuid,nodev,noexec,relatime shared:11 - cgroup cgroup rw,hugetlb
+29 24 0:24 / /sys/fs/cgroup/perf_event rw,nosuid,nodev,noexec,relatime shared:12 - cgroup cgroup rw,perf_event
+30 24 0:25 / /sys/fs/cgroup/net_cls,net_prio rw,nosuid,nodev,noexec,relatime shared:13 - cgroup cgroup rw,net_prio,net_cls
+31 24 0:26 / /sys/fs/cgroup/blkio rw,nosuid,nodev,noexec,relatime shared:14 - cgroup cgroup rw,blkio
+32 24 0:27 / /sys/fs/cgroup/devices rw,nosuid,nodev,noexec,relatime shared:15 - cgroup cgroup rw,devices
+33 24 0:28 / /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:16 - cgroup cgroup rw,pids
+34 24 0:29 / /sys/fs/cgroup/freezer rw,nosuid,nodev,noexec,relatime shared:17 - cgroup cgroup rw,freezer
+35 24 0:30 / /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,memory
+36 24 0:31 / /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:19 - cgroup cgroup rw,cpuset
+58 17 0:32 / /sys/kernel/config rw,relatime shared:21 - configfs configfs rw
+60 1 253:0 / / rw,relatime shared:1 - xfs /dev/mapper/cl-root rw,seclabel,attr2,inode64,noquota
+37 17 0:14 / /sys/fs/selinux rw,relatime shared:22 - selinuxfs selinuxfs rw
+38 18 0:33 / /proc/sys/fs/binfmt_misc rw,relatime shared:24 - autofs systemd-1 rw,fd=25,pgrp=1,timeout=300,minproto=5,maxproto=5,direct
+39 17 0:6 / /sys/kernel/debug rw,relatime shared:25 - debugfs debugfs rw
+40 19 0:34 / /dev/hugepages rw,relatime shared:26 - hugetlbfs hugetlbfs rw,seclabel
+41 19 0:13 / /dev/mqueue rw,relatime shared:27 - mqueue mqueue rw,seclabel
+72 60 8:1 / /boot rw,relatime shared:28 - xfs /dev/sda1 rw,seclabel,attr2,inode64,noquota
+74 60 253:2 / /home rw,relatime shared:29 - xfs /dev/mapper/cl-home rw,seclabel,attr2,inode64,noquota
+150 60 253:0 /var/lib/docker/devicemapper /var/lib/docker/devicemapper rw,relatime - xfs /dev/mapper/cl-root rw,seclabel,attr2,inode64,noquota
+109 23 0:35 / /run/user/1000 rw,nosuid,nodev,relatime shared:62 - tmpfs tmpfs rw,seclabel,size=388200k,mode=700,uid=1000,gid=1000
+116 38 0:36 / /proc/sys/fs/binfmt_misc rw,relatime shared:66 - binfmt_misc binfmt_misc rw
+113 17 0:37 / /sys/fs/fuse/connections rw,relatime shared:65 - fusectl fusectl rw
+119 74 253:2 /akutz/1 /home/akutz/2 rw,relatime shared:29 - xfs /dev/mapper/cl-home rw,seclabel,attr2,inode64,noquota
+`


### PR DESCRIPTION
This patch updates the way GetMounts collects mount information for Linux. Instead of using /proc/mounts the mount_namespaces feature present since Linux Kernel 2.2.26 at /proc/<pid>/mountinfo is leveraged. This method enables the addition of the Source field to the Info struct, providing a means to map a bind mount back to the source path and not just the device on which the original path exists.