### PR TITLE
Idempotent Errors

### DIFF
--- a/trylock.go
+++ b/trylock.go
@@ -15,8 +15,6 @@ type MutexWithTryLock interface {
 	TryLock(timeout time.Duration) bool
 }
 
-var tryLockNow = time.Duration(0)
-
 type mutex struct {
 	c chan int
 }


### PR DESCRIPTION
This patch updates the idempotent interceptor to allow for the cases where the guarded operation returns an error. If it does, that call for that volume will be marked as in error and a subsequent, same call for that volume will bypass the idempotent guard. Not until the handler returns a successful operation will the idempotent guard take effect once again for that volume for that particular operation.